### PR TITLE
CEMS API V2 Swagger documentation to retrieve Providers for a University CEMS-2019 

### DIFF
--- a/cems-api.yml
+++ b/cems-api.yml
@@ -4331,6 +4331,32 @@ paths:
         404:
           description: "Company or course not found"
           
+  /company/{companyId}/providers:
+    get:
+      tags:
+        - "Company"
+      summary: "Get a list of Providers for a company"
+      description: ""
+      produces:
+        - "application/json"
+      parameters:
+        - name: "companyId"
+          in: "path"
+          description: ""
+          required: true
+          type: "integer"
+      responses:
+        200:
+          description: "Success"
+          schema:
+            $ref: "#/definitions/Provider"
+        401:
+          description: "Not authenticated"
+        403:
+          description: "Not authorized"
+        404:
+          description: "Company not found"
+
   /enrollment/{enrollmentId}:
     get:
       tags:
@@ -6645,7 +6671,24 @@ definitions:
           accreditations: 
             type: "string"
             example: "/api/v2/accreditations?courseId=9876&activeOnDate=2020-01-30"
-            
+
+  Provider:
+    type: "object"
+    required:
+      - "data"
+    properties:
+      data:
+        type: "array"
+        items:
+          type: "object"
+          properties:
+            id:
+              type: "number"
+              example: 2
+            name:
+              type: "string"
+              example: "provider_google"
+
   Accreditations:
     type: "object"
     required: 

--- a/cems-api.yml
+++ b/cems-api.yml
@@ -4331,11 +4331,11 @@ paths:
         404:
           description: "Company or course not found"
           
-  /company/{companyId}/providers:
+  /sso/company/{companyId}/providers:
     get:
       tags:
         - "Company"
-      summary: "Get a list of Providers for a company"
+      summary: "Get a list of SSO Providers for a company"
       description: ""
       produces:
         - "application/json"


### PR DESCRIPTION
This change updates the CEMS API V2 Swagger documentation with a new GET request to retrieve a list of providers for a university.

Created a new sso branch to handle specifications.

To test, open the Swagger documentation and examine the new GET request for "//company/{companyId}/providers" and:

Verify description is correct
Examine the sample response, and verify the backend will be generating a response in the format specified
Verify the backend will handles scenarios to generates a 200, 401, 403 and 404
